### PR TITLE
Fix minio version to 7.2.0

### DIFF
--- a/RetrievalAugmentedGeneration/requirements.txt
+++ b/RetrievalAugmentedGeneration/requirements.txt
@@ -9,3 +9,4 @@ llama-index==0.9.13
 pymilvus==2.3.1
 dataclass-wizard==0.22.2
 opencv-python==4.8.0.74
+minio==7.2.0


### PR DESCRIPTION
- Avoid pulling in latest version of minio to fix a dependency issue caused by the latest version
- Fixes https://github.com/NVIDIA/GenerativeAIExamples/issues/19
