### PR TITLE
change to multi-node k8s

### DIFF
--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/frontend.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/frontend.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
 
       imagePullSecrets:
-        - name:   nvcrio
+        - name: {{ .Values.images.registry.ImagePullSecret.name }}
       containers:
       - name: llm-playground
         imagePullPolicy: IfNotPresent
@@ -27,9 +27,9 @@ spec:
         - frontend
         - --port
         - "8090"
-        env: 
+        env:
         - name: APP_MODELNAME
-          value: {{ .Values.frontend.modelName }} 
+          value: {{ .Values.frontend.modelName }}
         - name: APP_SERVERPORT
           value: "8081"
         - name: APP_SERVERURL
@@ -49,4 +49,3 @@ spec:
     - protocol: TCP
       port: 8090
       nodePort: 30001
-    

--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/jupyter-server.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/jupyter-server.yaml
@@ -15,7 +15,7 @@ spec:
         app.kubernetes.io/name: jupyter-notebook-server
     spec:
       imagePullSecrets:
-        - name:   nvcrio
+        - name: {{ .Values.images.registry.ImagePullSecret.name }}
       containers:
       - name: jupyter-notebook-server
         imagePullPolicy: IfNotPresent
@@ -24,7 +24,7 @@ spec:
         - containerPort: 8888
         resources:
           limits:
-            {{ .Values.jupyter.gpu.type }}: {{ .Values.jupyter.gpu.count }} 
+            {{ .Values.jupyter.gpu.type }}: {{ .Values.jupyter.gpu.count }}
 ---
 apiVersion: v1
 kind: Service
@@ -38,4 +38,4 @@ spec:
   ports:
     - protocol: TCP
       port: 8888
-      nodePort: 30000 
+      nodePort: 30000

--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/milvus-etcd.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/milvus-etcd.yaml
@@ -33,7 +33,7 @@ spec:
           value: "4294967296"
         - name: ETCD_SNAPSHOT_COUNT
           value: "50000"
-        ports:  
+        ports:
         - containerPort: 2379
         readinessProbe:
           exec:
@@ -48,9 +48,21 @@ spec:
           name: etcd-data
       volumes:
       - name: etcd-data
-        hostPath:
-          path: /etcd
-          type: DirectoryOrCreate
+        persistentVolumeClaim:
+          claimName: {{ .Values.milvus.etcd.pvcName }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.milvus.etcd.pvcName }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.milvus.etcd.pvcSize }}
+      
 ---
 apiVersion: v1
 kind: Service
@@ -62,4 +74,4 @@ spec:
   ports:
     - protocol: TCP
       port: 2379
-      targetPort: 2379 
+      targetPort: 2379

--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/milvus-minio.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/milvus-minio.yaml
@@ -44,9 +44,21 @@ spec:
           periodSeconds: 5
       volumes:
       - name: minio-data
-        hostPath:
-          path: /minio_data
-          type: DirectoryOrCreate
+        persistentVolumeClaim:
+          claimName: {{ .Values.milvus.minio.pvcName }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.milvus.minio.pvcName }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.milvus.minio.pvcSize }}
+
 ---
 apiVersion: v1
 kind: Service
@@ -59,4 +71,3 @@ spec:
     - protocol: TCP
       port: 9010
       targetPort: 9010
-

--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/query.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/query.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
 
       imagePullSecrets:
-        - name:   nvcrio
+        - name: {{ .Values.images.registry.ImagePullSecret.name }}
       volumes:
       - name: dshm
         emptyDir:
@@ -32,7 +32,7 @@ spec:
         - "8081"
         - --host
         - 0.0.0.0
-        env: 
+        env:
         - name: APP_MILVUS_URL
           value: http://milvus:19530
         - name: APP_LLM_SERVERURL
@@ -43,14 +43,14 @@ spec:
           value: triton-trt-llm
 #        - name: APP_CONFIG_FILE # THIS SHOULD BE A CONFIGMAP
 #         value: ""
-        ports:  
+        ports:
         - containerPort: 8081
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
         resources:
           limits:
-            {{ .Values.query.gpu.type }}: {{ .Values.query.gpu.count }} 
+            {{ .Values.query.gpu.type }}: {{ .Values.query.gpu.count }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/triton.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/templates/triton.yaml
@@ -7,14 +7,15 @@ data:
     #!/bin/bash -x
     set -e
 
-    rm -rf /usr/local/cuda-12.2/targets/x86_64-linux/lib/stubs/   
-    ldconfig 
-    
+    rm -rf /usr/local/cuda-12.2/targets/x86_64-linux/lib/stubs/
+    ldconfig
+
     /usr/bin/python3 -m  model_server {{ .Values.triton.modelArchitecture | quote }}  \
       --max-input-length {{ .Values.triton.modelMaxInputLength | quote}} \
-      --max-output-length {{ .Values.triton.modelMaxOutputLength | quote}}
-   
---- 
+      --max-output-length {{ .Values.triton.modelMaxOutputLength | quote}} \
+      --quantization {{ .Values.triton.quantization | quote}}
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +34,7 @@ spec:
         app.kubernetes.io/name: triton-inference-server
     spec:
       imagePullSecrets:
-        - name:   nvcrio
+        - name: {{ .Values.images.registry.ImagePullSecret.name }}
       containers:
       - name: triton-inference-server
         imagePullPolicy: IfNotPresent
@@ -50,10 +51,10 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            {{ .Values.triton.gpu.type }}: {{ .Values.triton.gpu.count }} 
+            {{ .Values.triton.gpu.type }}: {{ .Values.triton.gpu.count }}
         volumeMounts:
         - mountPath: /model
-          name: model 
+          name: model
         - mountPath: /dev/shm
           name: dshm
         - name: entrypoint
@@ -62,15 +63,15 @@ spec:
           subPath: entrypoint.sh
       volumes:
       - name: model
-        hostPath:
-          path: {{ .Values.triton.modelDirectory }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.triton.modelPVC }}
       - name: dshm
         emptyDir:
           medium: Memory
       - name: entrypoint
         configMap:
           defaultMode: 0700
-          name: triton-entrypoint 
+          name: triton-entrypoint
 ---
 apiVersion: v1
 kind: Service
@@ -83,4 +84,3 @@ spec:
     - protocol: TCP
       port: 8001
       targetPort: 8001
-

--- a/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/values.yaml
+++ b/deploy/k8s-operator/kube-trailblazer/helm-charts/staging/rag-llm-pipeline/values.yaml
@@ -2,7 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 triton:
-  modelDirectory: "/zvonkok/model/llama2_13b_chat_hf_v1/"
+  modelPVC: "llama2"
+  quantization: "None"
   modelArchitecture: "llama"
   modelMaxInputLength: "3000"
   modelMaxOutputLength: "512"
@@ -10,16 +11,22 @@ triton:
   gpu:
     # MIG slice
     #type: "nvidia.com/mig-3g.40gb"
-    # time-slice 
+    # time-slice
     type: "nvidia.com/gpu"
     count: 1
 
 milvus:
   gpu:
-    # MIG slice 
+    # MIG slice
     #type: "nvidia.com/mig-2g.20gb"
     type: "nvidia.com/gpu"
     count: 1
+  etcd:
+    pvcName: "etcd-data"
+    pvcSize: "20Gi"  
+  minio:
+    pvcName: "minio-data"
+    pvcSize: "40Gi"
 
 jupyter:
   image: localhost:5000/notebook-server
@@ -37,7 +44,7 @@ query:
     type: "nvidia.com/gpu"
     count: 1
 
-frontend: 
+frontend:
   image: localhost:5000/llm-playground
   modelName: "Llama-2-13b-chat-hf"
 
@@ -53,4 +60,4 @@ images:
       # credentials are needed.
       create: false
       username: '$oauthtoken'
-      password: 
+      password:


### PR DESCRIPTION
Changing local volumes from "hostPath" to "PersistentVolumeClaim" will make this solution work well on multi-node K8S clusters. Single-Node K8S cluster could also run as well, for examples: Microk8s could set "hostPath" as the "Default Storage Class".