### PR TITLE
Knowledge Graph RAG: fix setup

### DIFF
--- a/experimental/knowledge_graph_rag/README.md
+++ b/experimental/knowledge_graph_rag/README.md
@@ -85,17 +85,22 @@ python3 -m virtualenv venv
 source venv/bin/activate
 ```
 
-### 4. Install the required packages
+### 4. Install external dependencies
+```bash
+sudo apt install poppler-utils ffmpeg libsm6 libxext6 tesseract-ocr libtesseract-dev
+```
+
+### 5. Install the required packages
 
 ```bash
 pip install -r requirements.txt
 ```
 
-### 5. Setup a hosted Milvus vector database
+### 6. Setup a hosted Milvus vector database
 
 Follow the instructions [here](https://milvus.io/docs/install_standalone-docker.md) to deploy a hosted Milvus instance for the vector database backend. Note that it must be Milvus 2.4 or better to support [hybrid search](https://milvus.io/docs/multi-vector-search.md). We do not support disabling this feature for previous versions of Milvus as of now.
 
-### 5. Launch the Streamlit frontend
+### 7. Launch the Streamlit frontend
 
 ```bash
 streamlit run app.py
@@ -103,7 +108,7 @@ streamlit run app.py
 
 Open the URL in your browser to access the UI and chatbot!
 
-### 6. Upload Docs and Train Model
+### 8. Upload Docs and Train Model
 
 Upload your own documents to a folder, or use an existing folder for the knowledge graph creation. Note that the implementation currently focuses on text from PDFs only. It can be extended to other text file formats using the Unstructured.io data loader in LangChain.
 

--- a/experimental/knowledge_graph_rag/app.py
+++ b/experimental/knowledge_graph_rag/app.py
@@ -25,6 +25,9 @@ from utils.lc_graph import process_documents, save_triples_to_csvs
 from vectorstore.search import SearchHandler
 from langchain_nvidia_ai_endpoints import ChatNVIDIA
 
+import nltk
+nltk.download('averaged_perceptron_tagger')
+
 def load_data(input_dir, num_workers):
     reader = SimpleDirectoryReader(input_dir=input_dir)
     documents = reader.load_data(num_workers=num_workers)

--- a/experimental/knowledge_graph_rag/requirements.txt
+++ b/experimental/knowledge_graph_rag/requirements.txt
@@ -7,8 +7,8 @@ llama_index==0.10.50
 networkx==3.2.1
 numpy==1.24.1
 pandas==2.2.2
-pymilvus==2.4.3
-Requests==2.32.3
+pymilvus[model]==2.4.3
+Requests==2.31.0
 streamlit==1.30.0
 unstructured[all-docs]
 tqdm==4.66.1

--- a/experimental/knowledge_graph_rag/utils/lc_graph.py
+++ b/experimental/knowledge_graph_rag/utils/lc_graph.py
@@ -15,7 +15,7 @@
 
 from langchain_nvidia_ai_endpoints import ChatNVIDIA
 import concurrent.futures
-from preprocessor import extract_triples
+from utils.preprocessor import extract_triples
 from tqdm import tqdm
 from langchain_community.document_loaders import DirectoryLoader
 from langchain.text_splitter import RecursiveCharacterTextSplitter


### PR DESCRIPTION
First of all, thank you for sharing these projects with the public! I tried running your knowledge graph RAG on a fresh WSL install of Ubuntu 22.04.4 LTS (GNU/Linux 5.15.153.1-microsoft-standard-WSL2 x86_64). In this PR, I documented the changes I had to make in order to run the code. I am unsure if all of these steps are necessarily correct in all cases, but nevertheless I hope that these improvements in the README and code make life easier for the next person trying out this project.

# External Dependencies

```
sudo apt install poppler-utils ffmpeg libsm6 libxext6 tesseract-ocr libtesseract-dev
```

I had to install some external packages that are being called by python packages. 
- `poppler-utils` is necessary to be able to read PDF files. python packages such as `pdf2image` use it.
- `ffmpeg libsm6 libxext6` are common cv2 dependencies. Before installing them, I was confronted with a `ImportError: libGL.so.1: cannot open shared object file: No such file or directory` when trying to process files into the system. This list of packages work, but there might be a more compact way to provide the necessary libraries. 
- `tesseract-ocr libtesseract-dev` are necessary for `pytesseract`. This is used to parse a PDF into a string.

# Changes in `requirements.txt`

```
Requests==2.31.0
```
The `requirements.txt` file specifies `Requests==2.32.3`, but another specified dependency requires 2.31.0, making pip unable to resolve the dependency issue.

```
pymilvus[model]==2.4.3
```
Without the model feature, preprocessing of files eventually runs into a runtime exception.

# Changes in the code

```
import nltk
nltk.download('averaged_perceptron_tagger')
```
I added this snippet at the top of the code to simply make sure the necessary files are there when needed. I am very sure there is a much more suitable spot for this. Please let me know!

```
from utils.preprocessor import extract_triples
```
Running the project as described in the README led to issues with the import statements. They were fixed for me by using the full path of the module structure.