### PR TITLE
 Add CTA for Gradio-based RAG Q&A app

### DIFF
--- a/RAG/notebooks/llamaindex/llamaindex_basic_RAG.ipynb
+++ b/RAG/notebooks/llamaindex/llamaindex_basic_RAG.ipynb
@@ -12,9 +12,11 @@
    "cell_type": "markdown",
    "id": "2969cdab-82fc-4ce5-bde1-b4f629691f27",
    "metadata": {},
-   "source": [
-    "This notebook introduces how to use LlamaIndex to interact with NVIDIA hosted NIM microservices like chat, embedding, and reranking models to build a simple retrieval-augmented generation (RAG) application."
-   ]
+   "source":  [
+  "This notebook introduces how to use LlamaIndex to interact with NVIDIA hosted NIM microservices like chat, embedding, and reranking models to build a simple retrieval-augmented generation (RAG) application.\n",
+  "\n",
+  "Alternatively, for a more interactive experience with a graphical user interface, you can refer to our Gradio-based RAG Q&A application that also uses NVIDIA hosted NIM microservices [here](https://github.com/jayrodge/llm-assistant-cloud-app/)."
+  ]
   },
   {
    "cell_type": "markdown",

--- a/RAG/notebooks/llamaindex/llamaindex_basic_RAG.ipynb
+++ b/RAG/notebooks/llamaindex/llamaindex_basic_RAG.ipynb
@@ -15,7 +15,7 @@
    "source":  [
   "This notebook introduces how to use LlamaIndex to interact with NVIDIA hosted NIM microservices like chat, embedding, and reranking models to build a simple retrieval-augmented generation (RAG) application.\n",
   "\n",
-  "Alternatively, for a more interactive experience with a graphical user interface, you can refer to our Gradio-based RAG Q&A application that also uses NVIDIA hosted NIM microservices [here](https://github.com/jayrodge/llm-assistant-cloud-app/)."
+  "Alternatively, for a more interactive experience with a graphical user interface, you can refer to our Gradio-based RAG Q&A reference application that also uses NVIDIA hosted NIM microservices [here](https://github.com/jayrodge/llm-assistant-cloud-app/)."
   ]
   },
   {


### PR DESCRIPTION
This PR adds a CTA in the llamaindex_basic_RAG.ipynb notebook, referencing a Gradio-based RAG Q&A reference app.
CC: @dglogo 