### PR TITLE
Updated versions for LLM, Embedding, and Reranking microservices used by the RAG pipelines

### DIFF
--- a/RAG/examples/local_deploy/docker-compose-nim-ms.yaml
+++ b/RAG/examples/local_deploy/docker-compose-nim-ms.yaml
@@ -1,7 +1,7 @@
 services:
   nemollm-inference:
     container_name: nemollm-inference-microservice
-    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.0
+    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.3
     volumes:
     - ${MODEL_DIRECTORY}:/opt/nim/.cache
     user: "${USERID}"
@@ -29,7 +29,7 @@ services:
 
   nemollm-embedding:
     container_name: nemo-retriever-embedding-microservice
-    image: nvcr.io/nim/nvidia/nv-embedqa-e5-v5:1.0.0
+    image: nvcr.io/nim/nvidia/nv-embedqa-e5-v5:1.0.1
     volumes:
     - ${MODEL_DIRECTORY}:/opt/nim/.cache
     ports:
@@ -57,7 +57,7 @@ services:
 
   ranking-ms:
     container_name: nemo-retriever-ranking-microservice
-    image: nvcr.io/nim/nvidia/nv-rerankqa-mistral-4b-v3:1.0.0
+    image: nvcr.io/nim/nvidia/nv-rerankqa-mistral-4b-v3:1.0.1
     volumes:
     - ${MODEL_DIRECTORY}:/opt/nim/.cache
     ports:


### PR DESCRIPTION
This PR updates the release versions of microservices used by the RAG pipelines to fix authentication issues when using new (Personal/Service) API keys.

| microservice                                   | current version | version in PR |
|------------------------------------------------|-----------------|---------------|
| LLM NIM (llama3-8b-instruct)                   | 1.0.0           | 1.0.3         |
| Text Embedding NIM (nv-embedqa-e5-v5)          | 1.0.0           | 1.0.1         |
| Text Reranking NIM (nv-rerankqa-mistral-4b-v3) | 1.0.0           | 1.0.1         |