### PR TITLE
Update docker compose plugin version in prerequisites

### DIFF
--- a/docs/common-prerequisites.md
+++ b/docs/common-prerequisites.md
@@ -26,7 +26,7 @@
 - Install Docker Engine and Docker Compose.
   Refer to the instructions for [Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 
-  Ensure the Docker Compose plugin version is 2.20 or higher.
+  Ensure the Docker Compose plugin version is 2.29.1 or higher.
   Run `docker compose version` to confirm.
   Refer to [Install the Compose plugin](https://docs.docker.com/compose/install/linux/)
   in the Docker documentation for more information.


### PR DESCRIPTION
Updates docker compose plugin version from `2.20` to `2.29.1` in common prerequisites documentation.