### PR TITLE
Update requirements.txt

### DIFF
--- a/community/multimodal-rag/requirements.txt
+++ b/community/multimodal-rag/requirements.txt
@@ -1,6 +1,5 @@
 pymupdf==1.22.5
 streamlit==1.38.0
-fitz==0.0.1.dev2
 python-pptx==1.0.2
 Pillow==10.4.0
 requests==2.32.3


### PR DESCRIPTION
**Description**
This PR addresses a conflict between the `fitz` and `pymupdf` libraries in the `requirements.txt` file of the [Multimodal RAG](https://github.com/NVIDIA/GenerativeAIExamples/tree/main/community/multimodal-rag) example code. [Issue](https://github.com/NVIDIA/GenerativeAIExamples/issues/195)

**Issue**
The current `requirements.txt` file includes:

- `fitz==0.0.1.dev2`
- `pymupdf==1.22.5`

The `fitz` module, which is used for opening PDFs, is actually a part of the `pymupdf` package. This causes a conflict because different versions of `fitz` and `pymupdf` can lead to incompatibility issues, as noted in [this GitHub issue](https://github.com/pymupdf/PyMuPDF/issues/1155).

**Solution**
To resolve this conflict and ensure the code functions correctly, the `fitz==0.0.1.dev2` dependency has been removed from `requirements.txt`. The code should work seamlessly with `pymupdf` alone, as `pymupdf` includes the necessary `fitz` functionalities.

**Changes Made**

- Removed `fitz==0.0.1.dev2` from `requirements.txt`.

This update ensures compatibility and resolves the library conflict, enabling the Multimodal RAG example code to run without issues related to these dependencies.