### PR TITLE
Update gradio version to fix bug #188 in healthcare rag-playground example

### DIFF
--- a/industries/healthcare/medical-device-training-assistant/src/rag_playground/requirements.txt
+++ b/industries/healthcare/medical-device-training-assistant/src/rag_playground/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==6.0.1
 dataclass-wizard==0.22.3
-gradio==4.13.0
+gradio==4.43.0
 jinja2==3.1.3
 numpy==1.26.4
 opentelemetry-api==1.23.0


### PR DESCRIPTION
- Updates `requirements.txt` file to upgrade the gradio version from 4.13.0 to 4.43.0 to fix #188 for the isolated version of the `rag_playground` in the healthcare `medical-device-training-assistant` example