### PR TITLE
Update README.md "Try it Now!"

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ For more information, refer to the [Generative AI Example releases](https://gith
 
 Experience NVIDIA RAG Pipelines with just a few steps!
 
-1. Get your NVIDIA API key.
+1. Get your NVIDIA NGC API key.
    1. Go to the [NVIDIA API Catalog](https://build.ngc.nvidia.com/explore/).
    1. Select any model.
    1. Click **Get API Key**.
    1. Run:
       ```console
-      export NVIDIA_API_KEY=nvapi-...
+      export NGC_API_KEY=nvapi-...
       ``` 
 
 1. Clone the repository.
@@ -76,7 +76,7 @@ Experience NVIDIA RAG Pipelines with just a few steps!
    docker compose up -d --build
    ```
 
-1. Go to <https://localhost:8090/> and submit queries to the sample RAG Playground.
+1. Go to <http://localhost:8090/> and submit queries to the sample RAG Playground.
 
 1. Stop containers when done. 
   


### PR DESCRIPTION
- Expects `NGC_API_KEY` per the warning in the output:
```
WARN[0000] The "NGC_API_KEY" variable is not set. Defaulting to a blank string. 
```

- The `https://` should be `http://` for the route to the UI at `http://localhost:8090/`
