### PR TITLE
Add huggingface version in requirements

### DIFF
--- a/community/oran-chatbot-multimodal/requirements.txt
+++ b/community/oran-chatbot-multimodal/requirements.txt
@@ -5,6 +5,7 @@ datasets
 docx2txt
 faiss-cpu
 fastapi==0.104.1
+huggingface_hub==0.25
 gspread==6.0.0
 jupyterlab==4.0.8
 langchain==0.2.5


### PR DESCRIPTION
HF_hub 0.26 discontinued support to cached_download, which is needed for this chatbot. Reverting to HF_hub 0.25 to avoid errors.
[Reference Link](https://github.com/huggingface/huggingface_hub/releases/tag/v0.26.0#:~:text=have%20been%20introduced%3A-,cached_download,-()%2C%20url_to_filename)