### PR TITLE
Fixed the API catalog URL in the Try It Now section -s

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Follow the links below to learn more:
 Experience NVIDIA RAG Pipelines with just a few steps!
 
 1. Get your NVIDIA API key.
-   1. Go to the [NVIDIA API Catalog](https://build.ngc.nvidia.com/explore/).
+   1. Go to the [NVIDIA API Catalog](https://build.nvidia.com/explore/).
    1. Select any model.
    1. Click **Get API Key**.
    1. Run:


### PR DESCRIPTION
The current version of the README uses an invalid URL https://build.ngc.nvidia.com/explore/ 
So the browser hangs when you click on the link. 

The correct URL is https://build.nvidia.com/explore/

This commit replaces the invalid URL with the correct one.