### PR TITLE
Fix typos and copy-pasteos in Auditor notebook

### DIFF
--- a/nemo/NeMo-Auditor/Getting_Started_With_NeMo_Auditor.ipynb
+++ b/nemo/NeMo-Auditor/Getting_Started_With_NeMo_Auditor.ipynb
@@ -41,31 +41,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "28273bbd-c084-40ff-8f5a-263e16e64883",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enter you NVIDIA API Key:  ········\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✓ NVIDIA API Key set successfully\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import os\n",
     "import getpass\n",
     "\n",
     "if not os.environ.get(\"NVIDIA_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
-    "    nvidia_api_key = getpass.getpass(\"Enter you NVIDIA API Key: \")\n",
+    "    nvidia_api_key = getpass.getpass(\"Enter your NVIDIA API Key: \")\n",
     "    assert nvidia_api_key.startswith(\"nvapi-\"), \"Not a valid key\"\n",
     "    os.environ[\"NVIDIA_API_KEY\"] = nvidia_api_key\n",
     "    print(\"✓ NVIDIA API Key set successfully\")"
@@ -73,17 +58,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "id": "3cf8644d-51f1-44f9-8684-4c2afca9f349",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Enter you NIM API Key:  ········\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -97,8 +75,8 @@
     "import getpass\n",
     "\n",
     "if not os.environ.get(\"NIM_API_KEY\", \"\").startswith(\"nvapi-\"):\n",
-    "    nim_api_key = getpass.getpass(\"Enter you NIM API Key: \")\n",
-    "    assert nvidia_api_key.startswith(\"nvapi-\"), \"Not a valid key\"\n",
+    "    nim_api_key = getpass.getpass(\"Enter your NIM API Key: \")\n",
+    "    assert nim_api_key.startswith(\"nvapi-\"), \"Not a valid key\"\n",
     "    os.environ[\"NIM_API_KEY\"] = nim_api_key\n",
     "    print(\"✓ NIM API Key set successfully\")"
    ]
@@ -877,9 +855,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (NeMo Auditor)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "nemoauditor_env"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -891,7 +869,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed copy-paste error which used incorrect variable in subsequent cell.
Changed "Enter you (NVIDIA/NIM) API key" to "Enter your (NVIDIA/NIM) API key"