### PR TITLE
Fix broken API key hyperlink in knowledge_graph_rag README

### DIFF
--- a/community/knowledge_graph_rag/README.md
+++ b/community/knowledge_graph_rag/README.md
@@ -74,7 +74,7 @@ git clone https://github.com/NVIDIA/GenerativeAIExamples/ && cd GenerativeAIExam
 export NVIDIA_API_KEY="nvapi-*******************"
 ```
 
-If you don't have an API key, follow [these instructions](https://github.com/NVIDIA/GenerativeAIExamples/blob/main/docs/api-catalog.md#get-an-api-key-for-the-accessing-models-on-the-api-catalog) to sign up for an NVIDIA AI Foundation developer account and obtain access.
+If you don't have an API key, follow [these instructions](https://build.nvidia.com/explore/discover) to sign up for an NVIDIA AI Foundation developer account and obtain access.
 
 ### 3. Create a Python virtual environment and activate it
 


### PR DESCRIPTION
## Summary

- Fixed the broken hyperlink in `community/knowledge_graph_rag/README.md` that pointed to a non-existent file (`docs/api-catalog.md`)
- The old target `docs/api-catalog.md` has been removed from teh repository at some point, so the link was returning a 404
- Replaced with a direct link to the NVIDIA API Catalogue page at `build.nvidia.com/explore/discover`, which is the recognised canonical location for obtaining an API key (also referenced in `docs/common-prerequisites.md`)

## Test plan

- [ ] Verify the updated link in the rendered README navigates to the correct NVIDIA API Catalogue page
- [ ] Confirm no other links in the same file are broken

Closes #400