### PR TITLE
Fix typo in Parallel Rails Tutorial notebook

### DIFF
--- a/nemo/NeMo-Guardrails/Parallel_Rails_Tutorial.ipynb
+++ b/nemo/NeMo-Guardrails/Parallel_Rails_Tutorial.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Run Inference with Parallel Rails using NeMo Guardrails Microservice\n",
-    "Cuurently, NeMo Guardrails Microservice offers streaming with output rails. It is important to note that this feature exploits the assumption that rails are executed sequentially. But now, you can configure input and output rails to run in parallel. This can improve latency and throughput. This notebook is a walkthrough to understand how to use the Microservice for streaming with parallel rails.\n",
+    "Currently, NeMo Guardrails Microservice offers streaming with output rails. It is important to note that this feature exploits the assumption that rails are executed sequentially. But now, you can configure input and output rails to run in parallel. This can improve latency and throughput. This notebook is a walkthrough to understand how to use the Microservice for streaming with parallel rails.\n",
     "\n",
     "### 1. When to Use Parallel Rails Execution\n",
     "- Use parallel execution for I/O-bound rails such as external API calls to LLMs or third-party integrations.\n",


### PR DESCRIPTION
A most minor typo, but I saw it at the start of the passage. Sorry, can't help but correct this one small letter